### PR TITLE
Add options to event trigger process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PLANTUML_PUML			=	uml.puml
 PLANTUML_TARGET			=	$(PLANTUML_PUML:%.puml=%.svg)
 
 SOURCE		=	$(shell find include -name "*.hpp" -print)
+INC_HEADER	=	$(addprefix -I , $(shell find include -type d -print))
 
 INC_UML		=	$(addprefix -i , $(SOURCE))
 
@@ -10,7 +11,7 @@ clean:
 	rm -rf tests/dawa
 
 clean-doxygen:
-	rm -rf documentation/html
+	rm -rf documentation/docs
 	rm -rf documentation/latex
 
 clean-uml:
@@ -32,7 +33,7 @@ doxygen: clean-doxygen
 	touch documentation/docs/.nojekyll
 
 tests-run:
-	g++ ./tests/test-includes.cpp -I include -o tests/dawa
+	g++ ./tests/test-includes.cpp ${INC_HEADER} -std=c++20 -o tests/dawa
 	./tests/dawa
 
 .clang-format:

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,7 @@
+-Iinclude
+-Iinclude/Arcade
+-Iinclude/Arcade/Core
+-Iinclude/Arcade/ECS
+-Iinclude/Arcade/Game
+-Iinclude/Arcade/Graph
+-std=c++20

--- a/include/Arcade/ECS/IEventManager.hpp
+++ b/include/Arcade/ECS/IEventManager.hpp
@@ -115,7 +115,7 @@ namespace Arcade {
                  *
                  * @param event The event to add
                  */
-                virtual void addEvent(const std::string &event, std::optional<std::shared_ptr<IComponent>>) = 0;
+                virtual void addEvent(const std::string &event, std::optional<std::shared_ptr<IComponent>> = std::nullopt) = 0;
                 /**
                  * @brief Remove all events from list of trigered events
                  */

--- a/include/Arcade/ECS/IEventManager.hpp
+++ b/include/Arcade/ECS/IEventManager.hpp
@@ -9,7 +9,10 @@
 
 #include <queue>
 #include <string>
+#include <optional>
+#include <memory>
 #include "ArcadeStruct.hpp"
+#include "IComponent.hpp"
 
 namespace Arcade {
     namespace ECS {
@@ -104,22 +107,15 @@ namespace Arcade {
                  *
                  * @param event The event to check
                  *
-                 * @return True if the event was trigered, false otherwise
+                 * @return std::nullopt if there is no such event trigered else the std::optional passed as parameter of `addEvent` method
                  */
-                virtual bool isEventInQueue(const std::string &event) const = 0;
+                virtual std::optional<std::optional<std::shared_ptr<IComponent> &>> isEventInQueue(const std::string &event) const = 0;
                 /**
                  * @brief Add an event to list of trigered events
                  *
                  * @param event The event to add
                  */
-                virtual void addEvent(const std::string &event) = 0;
-                /**
-                 * @brief Remove an event from list of trigered events and
-                 * return it
-                 *
-                 * @return The event that was removed
-                 */
-                virtual const std::string &popEvent() = 0;
+                virtual void addEvent(const std::string &event, std::optional<std::shared_ptr<IComponent>>) = 0;
                 /**
                  * @brief Remove all events from list of trigered events
                  */

--- a/include/Arcade/ECS/IEventManager.hpp
+++ b/include/Arcade/ECS/IEventManager.hpp
@@ -117,8 +117,9 @@ namespace Arcade {
                  * @brief Add an event to list of trigered events
                  *
                  * @param event The event to add
+                 * @param component The component to add as optional parameter with the event
                  */
-                virtual void addEvent(const std::string &event, std::optional<std::shared_ptr<IComponent>> = std::nullopt) = 0;
+                virtual void addEvent(const std::string &event, std::optional<std::shared_ptr<IComponent>> component = std::nullopt) = 0;
                 /**
                  * @brief Remove all events from list of trigered events
                  */

--- a/include/Arcade/ECS/IEventManager.hpp
+++ b/include/Arcade/ECS/IEventManager.hpp
@@ -10,6 +10,7 @@
 #include <queue>
 #include <string>
 #include <optional>
+#include <tuple>
 #include <memory>
 #include "ArcadeStruct.hpp"
 #include "IComponent.hpp"
@@ -107,9 +108,11 @@ namespace Arcade {
                  *
                  * @param event The event to check
                  *
-                 * @return std::nullopt if there is no such event trigered else the std::optional passed as parameter of `addEvent` method
+                 * @return A pair of
+                 * bool (True if the event was trigered, False if the event was not trigered)
+                 * and std::optional<std::shared_ptr<IComponent>> (The parameter passed as parameter to `addEvent` method)
                  */
-                virtual std::optional<std::optional<std::shared_ptr<IComponent> &>> isEventInQueue(const std::string &event) const = 0;
+                virtual std::pair<bool, std::optional<std::shared_ptr<IComponent> &>> isEventInQueue(const std::string &event) const = 0;
                 /**
                  * @brief Add an event to list of trigered events
                  *

--- a/tests/test-pair-return.cpp
+++ b/tests/test-pair-return.cpp
@@ -1,0 +1,26 @@
+#include <optional>
+#include <tuple>
+#include <iostream>
+
+std::pair<bool, std::optional<int>> test_it(int a)
+{
+    if (a == 0) {
+        return std::make_pair(false, std::nullopt);
+    } else if (a == 1) {
+        return std::make_pair(true, std::nullopt);
+    } else {
+        return std::make_pair(true, a);
+    }
+}
+
+int main()
+{
+    bool a;
+    std::optional<int> b;
+    std::tie(a, b) = test_it(0);
+    std::cout << a << " " << b.has_value() << " " << b.value_or(0) << std::endl;
+    std::tie(a, b) = test_it(1);
+    std::cout << a << " " << b.has_value() << " " << b.value_or(0) << std::endl;
+    std::tie(a, b) = test_it(2);
+    std::cout << a << " " << b.has_value() << " " << b.value_or(0) << std::endl;
+}


### PR DESCRIPTION
Option are passed using an std::optional syntax.

This means that if you dont want to pass parameters, you can. But if you don't want to pass, you can.

When you check if an event is triggered, you receive an std::pair<bool, std::optional<std::shared_ptr<IComponent> &>>. the bool is like before, to know if event was trigered, and the std::optional is what you pass to addEvent

example how to use an std::optional or std::pair
```cpp
#include <optional>
#include <tuple>
#include <iostream>

std::pair<bool, std::optional<int>> test_it(int a)
{
    if (a == 0) {
        return std::make_pair(false, std::nullopt);
    } else if (a == 1) {
        return std::make_pair(true, std::nullopt);
    } else {
        return std::make_pair(true, a);
    }
}

int main()
{
    bool a;
    std::optional<int> b;
    std::tie(a, b) = test_it(0);
    std::cout << a << " " << b.has_value() << " " << b.value_or(0) << std::endl;
    std::tie(a, b) = test_it(1);
    std::cout << a << " " << b.has_value() << " " << b.value_or(0) << std::endl;
    std::tie(a, b) = test_it(2);
    std::cout << a << " " << b.has_value() << " " << b.value_or(0) << std::endl;
}

```