### PR TITLE
Replace TTY color type from RGBA to short

### DIFF
--- a/include/Arcade/Graph/GraphStruct.hpp
+++ b/include/Arcade/Graph/GraphStruct.hpp
@@ -21,8 +21,8 @@ namespace Arcade {
         struct TTYData {
             public:
                 std::string defaultChar;
-                Color foreground;
-                Color background;
+                short foregroundColor;
+                short backgroundColor;
         };
         struct Rect {
             public:


### PR DESCRIPTION
In ncurses, foreground and background are `short` that can be called using macros. This PR fixes TTY color types to fit ncurses.