### PR TITLE
Fix IComponent inheritance accessibility

### DIFF
--- a/include/Arcade/Graph/GraphStruct.hpp
+++ b/include/Arcade/Graph/GraphStruct.hpp
@@ -21,8 +21,8 @@ namespace Arcade {
         struct TTYData {
             public:
                 std::string defaultChar;
-                Color foreground;
-                Color background;
+                short foregroundColor;
+                short backgroundColor;
         };
         struct Rect {
             public:

--- a/include/Arcade/Graph/GraphStruct.hpp
+++ b/include/Arcade/Graph/GraphStruct.hpp
@@ -21,8 +21,8 @@ namespace Arcade {
         struct TTYData {
             public:
                 std::string defaultChar;
-                short foregroundColor;
-                short backgroundColor;
+                Color foreground;
+                Color background;
         };
         struct Rect {
             public:

--- a/include/Arcade/Graph/IMusic.hpp
+++ b/include/Arcade/Graph/IMusic.hpp
@@ -21,7 +21,7 @@ namespace Arcade {
          * ATTENTION: You must have a parameter in your constructor
          * in order to set his id.
          */
-        class IMusic : Arcade::ECS::IComponent {
+        class IMusic : public Arcade::ECS::IComponent {
             public:
                 virtual ~IMusic() = default;
                 /**

--- a/include/Arcade/Graph/ISprite.hpp
+++ b/include/Arcade/Graph/ISprite.hpp
@@ -23,7 +23,7 @@ namespace Arcade {
          * ATTENTION: You must have a parameter in your constructor
          * in order to set his id.
          */
-        class ISprite : Arcade::ECS::IComponent {
+        class ISprite : public Arcade::ECS::IComponent {
             public:
                 virtual ~ISprite() = default;
                 /**

--- a/include/Arcade/Graph/IText.hpp
+++ b/include/Arcade/Graph/IText.hpp
@@ -20,7 +20,7 @@ namespace Arcade {
          * The IText class is the class where you can manipulate text.
          * ATTENTION: This class is of CompType TEXT
          */
-        class IText : Arcade::ECS::IComponent {
+        class IText : public Arcade::ECS::IComponent {
             public:
                 virtual ~IText() = default;
                 /**


### PR DESCRIPTION
I'd like to make these inheritance `public` so that I can apply a `static_cast` on my sprite, text and music components. Without it, the default accessibility is private, which leads to this error:
`Arcade::ECS::IComponent’ is an inaccessible base of ‘Arcade::Graph::IText'`.

More details on this thread: https://stackoverflow.com/questions/9661936/inheritance-a-is-an-inaccessible-base-of-b