### PR TITLE
Fix DisplayModule getWindowSize

### DIFF
--- a/include/Arcade/Core/IDisplayModule.hpp
+++ b/include/Arcade/Core/IDisplayModule.hpp
@@ -99,7 +99,7 @@ namespace Arcade {
                 /**
                  * @brief Get he size of the window
                  */
-                virtual Arcade::Vector2f &getWindowSize() = 0;
+                virtual Arcade::Vector2f getWindowSize() = 0;
                 /**
                  * @brief Set the window size
                  *

--- a/include/Arcade/Core/IDisplayModule.hpp
+++ b/include/Arcade/Core/IDisplayModule.hpp
@@ -99,7 +99,7 @@ namespace Arcade {
                 /**
                  * @brief Get he size of the window
                  */
-                virtual Arcade::Vector2f getWindowSize() = 0;
+                virtual const Arcade::Vector2f &getWindowSize() const = 0;
                 /**
                  * @brief Set the window size
                  *


### PR DESCRIPTION
We don't need to return ref if we have a setter